### PR TITLE
Add info about VDDG and RAM training

### DIFF
--- a/DDR4 OC Guide.md
+++ b/DDR4 OC Guide.md
@@ -170,8 +170,8 @@ As far as I know, tCL, tRCD, tRP and possibly tRFC can (or can not) see voltage 
   On Ryzen 2000 (possibly 1000 and 3000 as well), above 1.15v can negatively impact overclocking.
   > There are clear differences in how the memory controller behaves on the different CPU specimens. The majority of the CPUs will do 3466MHz or higher at 1.050V SoC voltage, however the difference lies in how the different specimens react to the voltage. Some of the specimens seem scale with the increased SoC voltage, while the others simply refuse to scale at all or in some cases even illustrate negative scaling. All of the tested samples illustrated negative scaling (i.e. more errors or failures to train) when higher than 1.150V SoC was used. In all cases the maximum memory frequency was achieved at =< 1.100V SoC voltage.  
   [~ The Stilt](https://forums.anandtech.com/threads/ryzen-strictly-technical.2500572/page-72#post-39391302)
-  * On Ryzen 3000, there's also CLDO_VDDG (not to be confused with CLDO_VDD**P**), which is the voltage to the Infinity Fabric. I've read that SOC voltage should be at least 40mV above CLDO_VDDG, but other than that there's not much information about it.
-    > Most cLDO voltages are regulated from the two main power rails of the CPU. In case of cLDO_VDDG and cLDO_VDDP, they are regulated from the VDDCR_SoC plane.
+* On Ryzen 3000, there's also CLDO_VDDG (not to be confused with CLDO_VDD**P**), which is the voltage to the Infinity Fabric. I've read that SOC voltage should be at least 40mV above CLDO_VDDG, but other than that there's not much information about it.
+  > Most cLDO voltages are regulated from the two main power rails of the CPU. In case of cLDO_VDDG and cLDO_VDDP, they are regulated from the VDDCR_SoC plane.
 Because of this, there are couple rules. For example, if you set the VDDG to 1.100V, while your actual SoC voltage under load is 1.05V the VDDG will stay roughly at 1.01V max.
 Likewise if you have VDDG set to 1.100V and start increasing the SoC voltage, your VDDG will raise as well. I don't have the exact figure, but you can assume that the minimum drop-out voltage (Vin-Vout) is around 40mV.
 Meaning you ACTUAL SoC voltage has to be at least by this much higher, than the requested VDDG for it to take effect as it is requested.  
@@ -179,8 +179,6 @@ Adjusting the SoC voltage alone, unlike on previous gen. parts doesn't do much i
 The default value is fixed 1.100V and AMD recommends keeping it at that level. Increasing the VDDG helps with the fabric overclocking in certain scenarios, but not always.
 1800MHz FCLK should be doable at the default 0.9500V value and for pushing the limits it might be beneficial to increase it to =< 1.05V (1.100 - 1.125V SoC, depending on the load-line).  
   [~ The Stilt](https://www.overclock.net/forum/28031966-post35.html)
-  
-    When pushing FCLK around 1800 MHz intermittent RAM training errors may be alleviated or completely eliminated by increasing VDDG. On AGESA 1.0.0.4 or newer VDDG is separated into VDDG IOD and VDDG CCD for the I/O die and the chiplets parts, respectively. In this case the voltage to increase for more successful RAM training is VDDG CCD.
 
 * Below are the expected frequency ranges for 2 single rank DIMMs, provided your motherboard and ICs are capable:
 
@@ -394,6 +392,7 @@ This seems to line up with [The Stilt's](https://www.overclock.net/forum/10-amd-
 * On Ryzen 3000, higher CLDO_VDDP can help with stability above 3600MHz.
   > Increasing cLDO_VDDP seems beneficial > 3600MHz MEMCLKs, as increasing it seems to improve the margins and hence help with potential training issues.  
   [~ The Stilt](https://www.overclock.net/forum/10-amd-cpus/1728758-strictly-technical-matisse-not-really-26.html)
+* When pushing FCLK around 1800 MHz intermittent RAM training errors may be alleviated or completely eliminated by increasing VDDG. On AGESA 1.0.0.4 or newer VDDG is separated into VDDG IOD and VDDG CCD for the I/O die and the chiplets parts, respectively. In this case, the voltage to increase for more successful RAM training is VDDG CCD.
 
 # Useful Information
 * [r/overclocking Wiki - DDR4](https://www.reddit.com/r/overclocking/wiki/ram/ddr4)

--- a/DDR4 OC Guide.md
+++ b/DDR4 OC Guide.md
@@ -179,6 +179,8 @@ Adjusting the SoC voltage alone, unlike on previous gen. parts doesn't do much i
 The default value is fixed 1.100V and AMD recommends keeping it at that level. Increasing the VDDG helps with the fabric overclocking in certain scenarios, but not always.
 1800MHz FCLK should be doable at the default 0.9500V value and for pushing the limits it might be beneficial to increase it to =< 1.05V (1.100 - 1.125V SoC, depending on the load-line).  
   [~ The Stilt](https://www.overclock.net/forum/28031966-post35.html)
+  
+    When pushing FCLK around 1800 MHz intermittent RAM training errors may be alleviated or completely eliminated by increasing VDDG. On AGESA 1.0.0.4 or newer VDDG is separated into VDDG IOD and VDDG CCD for the I/O die and the chiplets parts, respectively. In this case the voltage to increase for more successful RAM training is VDDG CCD.
 
 * Below are the expected frequency ranges for 2 single rank DIMMs, provided your motherboard and ICs are capable:
 


### PR DESCRIPTION
I discovered this myself on my ASRock Taichi X570 w/ Ryzen 3900X.

Only one other user confirmed it:

https://www.reddit.com/r/ASRock/comments/dvqnto/x570_taichi_agesa_1004_patch_b_bios_officially/f7fywb6/

It might be ASRock specific or maybe people just don't care. Nobody infirmed it thus far.