### PR TITLE
Update DDR4 OC Guide.md

### DIFF
--- a/DDR4 OC Guide.md
+++ b/DDR4 OC Guide.md
@@ -511,8 +511,9 @@ The default value is fixed 1.100V and AMD recommends keeping it at that level. I
    On AMD, drop tRCD by 1 until unstable. Repeat with tRP.
    * Note: More IMC voltage may be necessary to stabilise tighter tRCD.
    
-7. Set `tRAS = tCL + tRCD(RD) + 2`. Increase if unstable.
-   * Setting tRAS lower than this can incur a [performance penalty](https://www.overclock.net/threads/official-intel-ddr4-24-7-memory-stability-thread.1569364/page-188#post-25801780).
+7. Set `tRAS = tRCD(RD) + tRTP`. Increase if unstable.
+   
+   * This Value is given by the JEDEC DDR4 Specification Document "JESD79-4C" on Page 132, link to the image can be found [here](https://user-images.githubusercontent.com/77159913/115368205-35263080-a20a-11eb-978e-48140129354f.png)
 
 8. Set `tRC = tRP + tRAS`. Increase if unstable.
    * tRC is only available on AMD and some Intel UEFIs.


### PR DESCRIPTION
tRAS rule is outdated and incorrect, needs an update.