### PR TITLE
Remove symbols from config name in absolutnew.cfg

### DIFF
--- a/TM5-Configs/absolutnew.cfg
+++ b/TM5-Configs/absolutnew.cfg
@@ -5,7 +5,7 @@ testmem.tz.ru
 serj_m@hotmail.com
 
 [Main Section]
-Config Name=ABSOLUT(01102021)
+Config Name=ABSOLUT
 Config Author=anta777
 Cores=0
 Tests=16


### PR DESCRIPTION
Not sure about this, but TM5 does not seem to accept symbols in config name. I am using latest TM5 v0.12 from https://iowin.net/en/testmem5-en/. Without this change, the config is not accepted by TM5 and gets overwritten with the default config.